### PR TITLE
Removed inappropriate words from assignment hashes

### DIFF
--- a/app/helpers/assignments_helper.rb
+++ b/app/helpers/assignments_helper.rb
@@ -1,6 +1,6 @@
 module AssignmentsHelper
-	MAX = 26**4-1; # the maximum number that can be hashed to
-    CODESTRING = "ydlgknmzxjbctfiaqsrwoevuhp"; # random ordering of the alphabet
+	MAX = 20**4-1; # the maximum number that can be hashed to
+    CODESTRING = "dlgknmzxjbctfqsrwvhp"; # random ordering of the alphabet
 
 	# a helper function that hashes an assignment number into a tag
     def hashID(number)
@@ -17,8 +17,8 @@ module AssignmentsHelper
     	result = "";
     	puts newnumber;
     	for i in 1..4
-    		result += CODESTRING[newnumber % 26];
-    		newnumber /= 26;
+    		result += CODESTRING[newnumber % 20];
+    		newnumber /= 20;
     	end
   		
   		return (result[2]+result[0]+result[3]+result[1]).upcase
@@ -29,7 +29,7 @@ module AssignmentsHelper
     	hash = (hash[1]+hash[3]+hash[0]+hash[2]).downcase;
     	newnumber = 0;
     	for i in (3).downto(0)
-    		newnumber *= 26;
+    		newnumber *= 20;
     		newnumber += CODESTRING.index(hash[i]);
     	end
     	if (newnumber <= MAX/4)

--- a/test/helpers/assignments_helper_test.rb
+++ b/test/helpers/assignments_helper_test.rb
@@ -1,6 +1,6 @@
 class AssignmentsHelperTest < ActionView::TestCase
   test "hashes should be unique" do
-  	max_value = 26**4-1 # 4 letters, 26 options, 0 indexed
+  	max_value = 20**4-1 # 4 letters, 26 options, 0 indexed
   	# collect all hashes
   	hashes = Array.new
   	for i in 0..max_value
@@ -11,7 +11,7 @@ class AssignmentsHelperTest < ActionView::TestCase
   end
 
   test "should hash and unhash properly" do
-  	max_value = 26**4-1 # 4 letters, 26 options, 0 indexed
+  	max_value = 20**4-1 # 4 letters, 26 options, 0 indexed
   	# make sure every number hashes to itself
   	for i in 0..max_value
 	   hashed = hashID(i)

--- a/test/helpers/assignments_helper_test.rb
+++ b/test/helpers/assignments_helper_test.rb
@@ -1,6 +1,6 @@
 class AssignmentsHelperTest < ActionView::TestCase
   test "hashes should be unique" do
-  	max_value = 20**4-1 # 4 letters, 26 options, 0 indexed
+  	max_value = 20**4-1 # 4 letters, 20 options, 0 indexed
   	# collect all hashes
   	hashes = Array.new
   	for i in 0..max_value
@@ -11,7 +11,7 @@ class AssignmentsHelperTest < ActionView::TestCase
   end
 
   test "should hash and unhash properly" do
-  	max_value = 20**4-1 # 4 letters, 26 options, 0 indexed
+  	max_value = 20**4-1 # 4 letters, 20 options, 0 indexed
   	# make sure every number hashes to itself
   	for i in 0..max_value
 	   hashed = hashID(i)


### PR DESCRIPTION
A quick and dirty solution: I removed all vowels from the hashes. We still allow some sketchy codes, like "nfck" which could be seen as inappropriate, but it should be good enough. We still have 160,000 possible hashes, and we can always move up to 5 letters if needed.